### PR TITLE
Switch liquidation calc to dYdX Chain formulas

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,4 +1,35 @@
-"""Core trading risk calculator logic."""
+"""
+Core trading risk calculator logic.
+
+Liquidation formulas follow dYdX Chain documentation:
+
+  Isolated:  p' = (e - s * p) / (|s| * MMF - s)
+  Cross:     p' = (e - s * p - MMR_o) / (|s| * MMF - s)
+
+Where:
+  e   = account equity (isolated: margin for this trade, cross: total equity)
+  s   = signed position size (+qty for long, -qty for short)
+  p   = entry price
+  MMF = maintenance margin fraction (e.g. 0.03 for BTC)
+  MMR_o = maintenance margin requirement from OTHER positions (cross only)
+"""
+
+# Default maintenance margin fractions (dYdX-style tiers)
+DEFAULT_MMF = {
+    "BTC": 0.03, "ETH": 0.03,
+    "SOL": 0.05, "XRP": 0.05, "BNB": 0.05, "ADA": 0.05,
+    "DOGE": 0.05, "AVAX": 0.05, "LINK": 0.05, "DOT": 0.05,
+    "LTC": 0.05, "TRX": 0.05, "MATIC": 0.05,
+    "NEAR": 0.10, "APT": 0.10, "UNI": 0.10, "SHIB": 0.10,
+    "XLM": 0.10, "USDT": 0.10, "USDC": 0.10,
+}
+
+FALLBACK_MMF = 0.05
+
+
+def get_mmf(symbol):
+    """Get maintenance margin fraction for a symbol."""
+    return DEFAULT_MMF.get(symbol.upper(), FALLBACK_MMF)
 
 
 def calc_position_size(balance, risk_pct, leverage):
@@ -8,85 +39,65 @@ def calc_position_size(balance, risk_pct, leverage):
     return margin, position_size
 
 
-def calc_liquidation_price(entry_price, leverage, side, mode, balance=0, total_margin_used=0):
+def calc_liquidation_isolated(entry_price, qty, side, margin, mmf):
     """
-    Calculate liquidation price.
+    dYdX isolated liquidation price.
 
-    For ISOLATED mode:
-        Long:  liq = entry * (1 - 1/leverage)
-        Short: liq = entry * (1 + 1/leverage)
+    Formula: p' = (e - s * p) / (|s| * MMF - s)
 
-    For CROSS mode:
-        Uses available balance as additional margin buffer.
-        Long:  liq = entry - (available_balance / (position_size / entry))
-        Short: liq = entry + (available_balance / (position_size / entry))
-        Simplified with leverage math.
+    Where e = margin (collateral for this position),
+          s = +qty (long) or -qty (short),
+          p = entry_price.
     """
-    if mode == "isolated":
-        if side == "long":
-            return entry_price * (1 - 1 / leverage)
-        else:
-            return entry_price * (1 + 1 / leverage)
-    else:
-        # Cross margin: entire available balance acts as margin
-        # available = balance - total_margin_used (from other isolated positions)
-        # effective_leverage is reduced because more margin backs the position
-        available = max(balance - total_margin_used, 0)
-        margin_for_this = available  # all free balance backs cross positions
-        if margin_for_this <= 0:
-            # No available balance, same as isolated
-            if side == "long":
-                return entry_price * (1 - 1 / leverage)
-            else:
-                return entry_price * (1 + 1 / leverage)
+    s = qty if side == "long" else -qty
+    e = margin
+    p = entry_price
 
-        # position_value = margin_for_this * leverage (but we use the trade's own margin * leverage)
-        # For cross, the liquidation distance is: margin_for_this / (position_qty)
-        # position_qty = (trade_margin * leverage) / entry_price
-        # But we don't have trade_margin here directly — caller passes what we need
-        # Simpler: effective_margin_ratio = available / (trade_margin * leverage)
-        # liq_long  = entry * (1 - effective_margin_ratio)
-        # liq_short = entry * (1 + effective_margin_ratio)
-        # We'll handle this in the Portfolio class where we have full context
-        # Fallback for standalone calc:
-        if side == "long":
-            return entry_price * (1 - 1 / leverage)
-        else:
-            return entry_price * (1 + 1 / leverage)
-
-
-def calc_liquidation_cross(entry_price, leverage, side, trade_margin, available_balance):
-    """
-    Cross-margin liquidation with full available balance as buffer.
-
-    available_balance = total_balance - sum(isolated margins) - sum(cross margins)
-    The full available_balance + trade_margin backs this position.
-    """
-    effective_margin = trade_margin + available_balance
-    position_size = trade_margin * leverage
-    qty = position_size / entry_price
-
-    if qty == 0:
+    denominator = abs(s) * mmf - s
+    if denominator == 0:
         return 0
 
-    if side == "long":
-        # Liquidation when loss = effective_margin
-        # (entry - liq) * qty = effective_margin
-        liq = entry_price - (effective_margin / qty)
-    else:
-        # (liq - entry) * qty = effective_margin
-        liq = entry_price + (effective_margin / qty)
-
+    liq = (e - s * p) / denominator
     return max(liq, 0)
 
 
-def calc_pnl(entry_price, current_price, qty, side, leverage=1):
+def calc_liquidation_cross(entry_price, qty, side, total_equity, mmf, mmr_other=0):
+    """
+    dYdX cross-margin liquidation price.
+
+    Formula: p' = (e - s * p - MMR_o) / (|s| * MMF - s)
+
+    Where e = total account equity,
+          s = +qty (long) or -qty (short),
+          p = entry_price,
+          MMR_o = sum of maintenance margin requirements from OTHER positions.
+    """
+    s = qty if side == "long" else -qty
+    e = total_equity
+    p = entry_price
+
+    denominator = abs(s) * mmf - s
+    if denominator == 0:
+        return 0
+
+    liq = (e - s * p - mmr_other) / denominator
+    return max(liq, 0)
+
+
+def calc_mmr(qty, price, mmf):
+    """
+    Maintenance margin requirement for a position at a given price.
+    MMR = |s| * price * MMF
+    """
+    return abs(qty) * price * mmf
+
+
+def calc_pnl(entry_price, current_price, qty, side):
     """Calculate unrealized P&L for a position."""
     if side == "long":
-        pnl = (current_price - entry_price) * qty
+        return (current_price - entry_price) * qty
     else:
-        pnl = (entry_price - current_price) * qty
-    return pnl
+        return (entry_price - current_price) * qty
 
 
 def calc_pnl_at_tp(entry_price, tp_price, margin, leverage, side):
@@ -117,21 +128,22 @@ def calc_risk_reward(entry_price, tp_price, liq_price, side):
     return reward / risk
 
 
-def quick_calculate(balance, risk_pct, leverage, entry_price, tp_price, side, mode):
+def quick_calculate(balance, risk_pct, leverage, entry_price, tp_price, side, mode, mmf=None):
     """
     One-shot calculation returning all key metrics.
     Returns a dict with all computed values.
     """
+    if mmf is None:
+        mmf = FALLBACK_MMF
+
     margin, position_size = calc_position_size(balance, risk_pct, leverage)
     qty = position_size / entry_price
 
     if mode == "isolated":
-        liq_price = calc_liquidation_price(entry_price, leverage, side, "isolated")
+        liq_price = calc_liquidation_isolated(entry_price, qty, side, margin, mmf)
     else:
-        # For standalone quick calc, cross uses full balance as buffer
-        liq_price = calc_liquidation_cross(
-            entry_price, leverage, side, margin, balance - margin
-        )
+        # Cross: total equity = balance, no other positions in standalone calc
+        liq_price = calc_liquidation_cross(entry_price, qty, side, balance, mmf, mmr_other=0)
 
     pnl_at_tp, roi = calc_pnl_at_tp(entry_price, tp_price, margin, leverage, side)
     rr = calc_risk_reward(entry_price, tp_price, liq_price, side)
@@ -156,4 +168,5 @@ def quick_calculate(balance, risk_pct, leverage, entry_price, tp_price, side, mo
         "leverage": leverage,
         "entry_price": entry_price,
         "tp_price": tp_price,
+        "mmf": mmf,
     }


### PR DESCRIPTION
Isolated: p' = (e - s*p) / (|s|*MMF - s)
Cross:    p' = (e - s*p - MMR_o) / (|s|*MMF - s)

- Add per-symbol maintenance margin fractions (BTC/ETH 3%, alts 5-10%)
- MMR_o correctly accounts for all other open positions in cross mode
- Verified against both examples in dYdX docs (short 3 ETH isolated, cross ETH+STRK) — results match exactly
- Quick calc now asks for symbol to auto-pick MMF, with manual override

https://claude.ai/code/session_01CgdHfSYp1wkdPiwQCLaYpT